### PR TITLE
fix async_register_admin_service on hass 2025.5

### DIFF
--- a/custom_components/yeelight_pro/__init__.py
+++ b/custom_components/yeelight_pro/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.reload import (
     async_integration_yaml_config,
     async_reload_integration_platforms,
 )
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.components import persistent_notification
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.config_validation as cv
@@ -149,8 +150,8 @@ class ComponentServices:
     def __init__(self, hass: HomeAssistant):
         self.hass = hass
 
-        hass.helpers.service.async_register_admin_service(
-            DOMAIN, SERVICE_RELOAD, self.handle_reload_config,
+        async_register_admin_service(
+            self.hass, DOMAIN, SERVICE_RELOAD, self.handle_reload_config,
         )
 
         hass.services.async_register(


### PR DESCRIPTION
fix on hass 2025.5

Logger: homeassistant.setup
Source: setup.py:426
First occurred: 4:56:28 PM (1 occurrence)
Last logged: 4:56:28 PM

Error during setup of component yeelight_pro: 'HomeAssistant' object has no attribute 'helpers'
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/setup.py", line 426, in _async_setup_component
result = await task
^^^^^^^^^^
File "/config/custom_components/yeelight_pro/init.py", line 76, in async_setup
ComponentServices(hass)
~~~~~~~~~~~~~~~~~^^^^^^
File "/config/custom_components/yeelight_pro/init.py", line 150, in init
hass.helpers.service.async_register_admin_service(
^^^^^^^^^^^^
AttributeError: 'HomeAssistant' object has no attribute 'helpers'