### PR TITLE
🔧 fix ATTR_COLOR_TEMP import removed in recent HA release

### DIFF
--- a/custom_components/yeelight_pro/light.py
+++ b/custom_components/yeelight_pro/light.py
@@ -10,11 +10,13 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntityFeature,
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
     ATTR_TRANSITION,
 )
+
+# ATTR_COLOR_TEMP ("color_temp", mireds) was removed in a recent HA release
+ATTR_COLOR_TEMP = "color_temp"
 
 from . import (
     XDevice,


### PR DESCRIPTION
Define ATTR_COLOR_TEMP locally as "color_temp" since it was removed from homeassistant.components.light, restoring compatibility.